### PR TITLE
Fix commons-vfs writeable flag and javadocs wrong author

### DIFF
--- a/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileObject.java
+++ b/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileObject.java
@@ -31,10 +31,9 @@ import com.github.junrar.rarfile.FileHeader;
 
 
 /**
- * A file in a Zip file system.
+ * A file in a RAR file system.
  * 
- * @author <a href="http://commons.apache.org/vfs/team-list.html">Commons VFS
- *         team</a>
+ * @author <a href="http://www.rogiel.com">Rogiel</a>
  */
 public class RARFileObject extends AbstractFileObject implements FileObject {
 	/**
@@ -58,7 +57,7 @@ public class RARFileObject extends AbstractFileObject implements FileObject {
 
 	@Override
 	public boolean doIsWriteable() throws FileSystemException {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileProvider.java
+++ b/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileProvider.java
@@ -33,10 +33,9 @@ import org.apache.commons.vfs2.provider.FileProvider;
 import org.apache.commons.vfs2.provider.LayeredFileName;
 
 /**
- * A file system provider for Zip files. Provides read-only file systems.
+ * A file system provider for RAR files. Provides read-only file systems.
  * 
- * @author <a href="http://commons.apache.org/vfs/team-list.html">Commons VFS
- *         team</a>
+ * @author <a href="http://www.rogiel.com">Rogiel</a>
  */
 public class RARFileProvider extends AbstractLayeredFileProvider implements
 		FileProvider {

--- a/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileSystem.java
+++ b/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/RARFileSystem.java
@@ -38,10 +38,9 @@ import com.github.junrar.rarfile.FileHeader;
 
 
 /**
- * A read-only file system for Zip/Jar files.
+ * A read-only file system for RAR files.
  * 
- * @author <a href="http://commons.apache.org/vfs/team-list.html">Commons VFS
- *         team</a>
+ * @author <a href="http://www.rogiel.com">Rogiel</a>
  */
 public class RARFileSystem extends AbstractFileSystem implements FileSystem {
 	private final FileObject parentLayer;

--- a/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/VFSVolume.java
+++ b/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/VFSVolume.java
@@ -31,7 +31,6 @@ import com.github.junrar.io.InputStreamReadOnlyAccessFile;
 
 /**
  * @author <a href="http://www.rogiel.com">Rogiel</a>
- * 
  */
 public class VFSVolume implements Volume {
 	private final Archive archive;

--- a/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/VFSVolumeManager.java
+++ b/unrar/src/main/java/com/github/junrar/vfs2/provider/rar/VFSVolumeManager.java
@@ -28,7 +28,6 @@ import com.github.junrar.util.VolumeHelper;
 
 /**
  * @author <a href="http://www.rogiel.com">Rogiel</a>
- * 
  */
 public class VFSVolumeManager implements VolumeManager {
 	private final FileObject firstVolume;


### PR DESCRIPTION
This is a small bug fix. RARFileObject instances were returning true when isWriteable() was called and javadoc at @author tags was written "Commons VFS Team"
